### PR TITLE
add removeSome method to remove by string contains in key

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ Returns the item with the specified key, or `undefined` if no item exists with t
 
 Removes the item with the specified key if it exists.
 
-## removeSome(subkey)
+## keys([subkey])
 
-Removes items that contain subkey in key and returns removed items.
+Get all keys from cache. If `subkey` parameter is present, then it returns only keys that contain `subkey`.
 
 ## clear()
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ Returns the item with the specified key, or `undefined` if no item exists with t
 
 Removes the item with the specified key if it exists.
 
+## removeSome(subkey)
+
+Removes items that contain subkey in key and returns removed items.
+
 ## clear()
 
 Removes all items from the cache.

--- a/src/LRUCache.cc
+++ b/src/LRUCache.cc
@@ -206,7 +206,7 @@ NAN_METHOD(LRUCache::Keys)
 
   for(HashMap::const_iterator it = cache->data.begin(); it != cache->data.end(); ++it)
   {
-    if (keyFilter == "" || isInString(it->first, key)) {
+    if (keyFilter == "" || isInString(it->first, keyFilter)) {
       keys.push_back(it->first);
     }
   }

--- a/src/LRUCache.cc
+++ b/src/LRUCache.cc
@@ -68,7 +68,7 @@ NAN_MODULE_INIT(LRUCache::init)
   Nan::SetPrototypeMethod(tpl, "clear", Clear);
   Nan::SetPrototypeMethod(tpl, "size", Size);
   Nan::SetPrototypeMethod(tpl, "stats", Stats);
-  Nan::SetPrototypeMethod(tpl, "removeSome", RemoveSome);
+  Nan::SetPrototypeMethod(tpl, "keys", Keys);
 
   Nan::Set(target, className, Nan::GetFunction(tpl).ToLocalChecked());
 }
@@ -197,34 +197,23 @@ NAN_METHOD(LRUCache::Get)
   }
 }
 
-NAN_METHOD(LRUCache::RemoveSome)
+NAN_METHOD(LRUCache::Keys)
 {
   LRUCache* cache = Nan::ObjectWrap::Unwrap<LRUCache>(info.Holder());
-  std::vector<std::string> result;
+  std::vector<std::string> keys;
 
-  if (info.Length() != 1)
-    return Nan::ThrowError(Nan::RangeError("Incorrect number of arguments for removeSome(), expected 1"));
-
-  std::string key = getStringValue(info[0]);
-
-  int count = 0;
+  std::string keyFilter = (info.Length() == 1) ? getStringValue(info[0]) : "";
 
   for(HashMap::const_iterator it = cache->data.begin(); it != cache->data.end(); ++it)
   {
-    if (isInString(it->first, key)) {
-      result.push_back(it->first);
-      count++;
+    if (keyFilter == "" || isInString(it->first, key)) {
+      keys.push_back(it->first);
     }
   }
 
-  v8::Local<v8::Array> arr = Nan::New<v8::Array>(count);
-  for(std::vector<int>::size_type i = 0; i != result.size(); i++) {
-    Nan::Set(arr, i, Nan::New<v8::String>(result[i]).ToLocalChecked());
-
-    const HashMap::iterator itr = cache->data.find(result[i]);
-
-    if (itr != cache->data.end())
-      cache->remove(itr);
+  v8::Local<v8::Array> arr = Nan::New<v8::Array>(keys.size());
+  for(std::vector<int>::size_type i = 0; i != keys.size(); i++) {
+    Nan::Set(arr, i, Nan::New<v8::String>(keys[i]).ToLocalChecked());
   }
 
   info.GetReturnValue().Set(arr);

--- a/src/LRUCache.h
+++ b/src/LRUCache.h
@@ -55,7 +55,7 @@ private:
 
   static NAN_METHOD(New);
   static NAN_METHOD(Get);
-  static NAN_METHOD(RemoveSome);
+  static NAN_METHOD(Keys);
   static NAN_METHOD(Set);
   static NAN_METHOD(Remove);
   static NAN_METHOD(Clear);

--- a/src/LRUCache.h
+++ b/src/LRUCache.h
@@ -55,6 +55,7 @@ private:
 
   static NAN_METHOD(New);
   static NAN_METHOD(Get);
+  static NAN_METHOD(RemoveSome);
   static NAN_METHOD(Set);
   static NAN_METHOD(Remove);
   static NAN_METHOD(Clear);

--- a/test/basics.tests.coffee
+++ b/test/basics.tests.coffee
@@ -33,6 +33,18 @@ describe 'basics', ->
         value = cache.get 'foo'
         assert value is undefined, "expected result to be undefined, was #{value}"
 
+    describe 'when removeSome() is called', ->
+
+      it 'should remove items that contain substring', ->
+        cache.set 'foo1', 42
+        cache.set 'foo2', 42
+        cache.set 'foo3', 42
+        cache.set 'bar4', 42
+        assert.equal cache.get('foo1'), 42
+        assert.deepEqual (cache.removeSome 'foo'), ['foo3', 'foo2', 'foo1']
+        value = cache.get 'foo3'
+        assert value is undefined, "expected result to be undefined, was #{value}"
+
     describe 'when size() is called', ->
 
       it 'should return the correct size', ->

--- a/test/basics.tests.coffee
+++ b/test/basics.tests.coffee
@@ -41,7 +41,7 @@ describe 'basics', ->
         cache.set 'foo3', 42
         cache.set 'bar4', 42
         assert.equal cache.get('foo1'), 42
-        assert.deepEqual (cache.removeSome 'foo'), ['foo3', 'foo2', 'foo1']
+        assert.deepEqual ((cache.removeSome 'foo').sort()), ['foo1', 'foo2', 'foo3']
         value = cache.get 'foo3'
         assert value is undefined, "expected result to be undefined, was #{value}"
 

--- a/test/basics.tests.coffee
+++ b/test/basics.tests.coffee
@@ -33,17 +33,23 @@ describe 'basics', ->
         value = cache.get 'foo'
         assert value is undefined, "expected result to be undefined, was #{value}"
 
-    describe 'when removeSome() is called', ->
+    describe 'when keys() is called', ->
 
-      it 'should remove items that contain substring', ->
+      it 'should return all keys', ->
         cache.set 'foo1', 42
         cache.set 'foo2', 42
         cache.set 'foo3', 42
         cache.set 'bar4', 42
         assert.equal cache.get('foo1'), 42
-        assert.deepEqual ((cache.removeSome 'foo').sort()), ['foo1', 'foo2', 'foo3']
-        value = cache.get 'foo3'
-        assert value is undefined, "expected result to be undefined, was #{value}"
+        assert.deepEqual ((cache.keys).sort), ['foo1', 'foo2', 'foo3', 'bar4']
+      
+      it 'should return keys that contain substring', ->
+        cache.set 'foo1', 42
+        cache.set 'foo2', 42
+        cache.set 'foo3', 42
+        cache.set 'bar4', 42
+        assert.equal cache.get('foo1'), 42
+        assert.deepEqual ((cache.keys 'foo').sort), ['foo1', 'foo2', 'foo3']
 
     describe 'when size() is called', ->
 

--- a/test/basics.tests.coffee
+++ b/test/basics.tests.coffee
@@ -41,7 +41,7 @@ describe 'basics', ->
         cache.set 'foo3', 42
         cache.set 'bar4', 42
         assert.equal cache.get('foo1'), 42
-        assert.deepEqual ((cache.keys).sort), ['foo1', 'foo2', 'foo3', 'bar4']
+        assert.deepEqual ((cache.keys()).sort()), ['foo1', 'foo2', 'foo3', 'bar4'].sort()
       
       it 'should return keys that contain substring', ->
         cache.set 'foo1', 42
@@ -49,7 +49,7 @@ describe 'basics', ->
         cache.set 'foo3', 42
         cache.set 'bar4', 42
         assert.equal cache.get('foo1'), 42
-        assert.deepEqual ((cache.keys 'foo').sort), ['foo1', 'foo2', 'foo3']
+        assert.deepEqual ((cache.keys 'foo').sort()), ['foo1', 'foo2', 'foo3']
 
     describe 'when size() is called', ->
 


### PR DESCRIPTION
I've added method to be able to remove cache items by a key's substring. This method is not so fast as direct removal by key, because it iterates over whole hash map, but it provides functionality that couldn't be achieved before.

This is quiet rough implementation mostly because I'm not c++ developer and maybe it's 3rd time in my life when I used to code in c++ :). So I will be grateful if you review this code.

May be it will be better to add something like removing by wildcard, but as my c++ knowledge is very limited, I not tried to do it, but I think it shouldn't be hard enough.